### PR TITLE
Add new filtered recipe endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -37,7 +37,14 @@ Will ignore auth token, can be added later if we really wanted it.
 
 `'/recipes'` - GET - Gets a random recipe
 
+`'/recipes/filter'` - GET - Gets a random recipe based on the filter provided. Pass in the filter query through parameters. Current supported parameters: ingredients (comma separated array)
+
+
+`'/recipes/ingredients'` - GET - Returns the supported ingredients that are found with the query. Pass in the query through parameters: query (string)
+
 --
 
 
 To add: /users/favouriteRecipes/get/:recipeName
+
+`'/recipes/restrictions'` - GET - Returns the supported restrictions

--- a/backend/routes/recipes.js
+++ b/backend/routes/recipes.js
@@ -1,8 +1,25 @@
 const fetch = require('node-fetch');
+
 var express = require('express');
 var router = express.Router();
 
 router.get('/', async (req, res, next) => {
+    const recipe = await getAPIRecipe();
+    return res.status(200).send(recipe);
+})
+
+router.get('/ingredients', async (req, res, next) => {
+
+})
+
+router.get('/restrictions', async (req, res, next) => {
+
+})
+
+router.get('/filter', async (req, res, next) => {
+    let filters = req.params;
+    let ingredients = filters.ingredients;
+    let restrictions = filters.restrictions;
     const recipe = await getAPIRecipe();
     return res.status(200).send(recipe);
 })

--- a/backend/routes/recipes.js
+++ b/backend/routes/recipes.js
@@ -1,6 +1,8 @@
 const fetch = require('node-fetch');
+require('dotenv').config();
 
 var express = require('express');
+const { URLSearchParams } = require('url');
 var router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -9,20 +11,101 @@ router.get('/', async (req, res, next) => {
 })
 
 router.get('/ingredients', async (req, res, next) => {
+    let filters = req.query;
+    let query = filters.query;
 
+    let uri = `${process.env.filteredRecipeAPIURI}/food/ingredients/autocomplete?`;
+    let params = new URLSearchParams({
+        query: query,
+        number: 5
+    });
+    const response = await fetch(uri + params,
+        {
+            method: 'GET',
+            headers: {
+                'x-api-key': process.env.spoonacularAPIKey
+            }
+        });
+
+    if (response.status != 200) {
+        return res.status(400).send({ error: "Something went wrong with the API call." });
+    }
+
+    return res.status(200).send(await response.json());
 })
 
-router.get('/restrictions', async (req, res, next) => {
+// router.get('/restrictions', async (req, res, next) => {
 
-})
+// })
 
 router.get('/filter', async (req, res, next) => {
-    let filters = req.params;
-    let ingredients = filters.ingredients;
-    let restrictions = filters.restrictions;
-    const recipe = await getAPIRecipe();
-    return res.status(200).send(recipe);
+    let filters = req.query;
+    let ingredientSearch = filters.ingredients;
+
+
+    let uri = `${process.env.filteredRecipeAPIURI}/recipes/complexSearch?`;
+    let params = new URLSearchParams({
+        query: ingredientSearch.split(",")[0],
+        includeIngredients: ingredientSearch,
+        instructionsRequired: true,
+        number: 20,
+        sort: "random",
+        sortDirection: "asc",
+        addRecipeNutrition: false,
+        addRecipeInformation: true,
+        fillIngredients: true,
+        instructionsRequired: true,
+    });
+
+
+    const response = await fetch(uri + params,
+        {
+            method: 'GET',
+            headers: {
+                'x-api-key': process.env.spoonacularAPIKey
+            }
+        });
+
+    if (response.status != 200) {
+        return res.status(400).send({ error: "Something went wrong with the API call." });
+    }
+
+    let json = await response.json();
+
+    if (json.results.length === 0) {
+        return res.status(400).send({ error: "Nothing was found, please try a different query." });
+    }
+
+    let recipe = json.results[0];
+
+    let ingredients = recipe.extendedIngredients.map((ingredient) => ingredient.originalName);
+
+    let directions = parseDirections(recipe.analyzedInstructions);
+
+    let item = {
+        title: recipe.title,
+        image: recipe.image,
+        ingredients: ingredients,
+        directions: directions,
+    }
+
+    return res.status(200).send(item);
 })
+
+function parseDirections(recipeDirections) {
+    let directions = "";
+    for (let instruction of recipeDirections) {
+        directions += `${instruction.name}:\n\n`
+        for (let stepNumber in instruction.steps) {
+            step = instruction.steps[stepNumber].step;
+            num = +stepNumber + 1;
+            directions += `${num}: ${step}\n`;
+        }
+        directions += "\n"
+    }
+
+    return directions;
+}
 
 const getAPIRecipe = async () => {
     const response = await fetch('https://www.themealdb.com/api/json/v1/1/random.php', {
@@ -46,5 +129,6 @@ const getAPIRecipe = async () => {
     };
     return Promise.resolve(item);
 };
+
 
 module.exports = router;


### PR DESCRIPTION
Added /recipes/ingredients and /recipes/filter to autocomplete search ingredients and search a random recipe based on the filter. The documentation is in the README, and the filter recipe search can trivially filter by cuisine/restrictions/diet. API key and .env additions will be in slack chat.